### PR TITLE
Fix missing newlines

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function middleware(file) {
   middleware.sanitize = function(text){
     text = text.replace(/\"/g, '\u005C\u0022')
     text = text.replace(/^(.*)/gm, '"$1')
-    text = text.replace(/(.+)$/gm, '$1" +')
+    text = text.replace(/(.+)$/gm, '$1 \\n" +')
     text = text.replace(/\+$/, '')
     return text
   }


### PR DESCRIPTION
I tried loading my shaders with this browserify package, but I encountered problems that stemmed from the minifying of the shader module. Removing the newlines caused these issues:
- // comments anywhere in the file would effectively comment out the rest of the shader
- #define declarations would cause errors in shader compilation

If you don't feel like incorporating the change I can just add the fork to NPM with some obscure name.

Thanks
