### PR TITLE
Added browserify options

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,20 @@ require("browserify-shader").extensions = ["vertexshader", "fragmentshader", "c"
 ```
 
 ## How to run 
+## Options
+The following options will work if you want to customize your transform:
 
+- parameterize: Boolean
+  - enables parameterised shaders, **Note:** if disabled, modules will be required/imported as strings instead of functions.
+- module: String
+  - configures module type incase your using an es6 transpiler with browserify, possibilities are "es6"/"es2015" and "common" (default).
 ### CLI:
 run browserify with the transform option:
 ```bash
 browserify -t browserify-shader entry-point.js
+```
+```bash
+browserify -t [browserify-shader --parameterize=true] entry-point.js
 ```
 
 ### Node/grunt:
@@ -101,7 +110,9 @@ var browserify = require("browserify");
 var browserifyShader = require("browserify-shader")
 
 browserify("./index.js");
-  .transform(browserifyShader);
+  .transform(browserifyShader, {
+     module: "es6"
+  });
   .bundle()
   .pipe(fs.createWriteStream("./bundle.js"));
 ```

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The following options will work if you want to customize your transform:
   - enables parameterised shaders, **Note:** if disabled, modules will be required/imported as strings instead of functions.
 - module: String
   - configures module type incase your using an es6 transpiler with browserify, possibilities are "es6"/"es2015" and "common" (default).
+  
 ### CLI:
 run browserify with the transform option:
 ```bash

--- a/example/bundle.js
+++ b/example/bundle.js
@@ -1,15 +1,7 @@
-(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-module.exports = function parse(params){
-      var template = "void main() {" +
-"  gl_FragColor = vec4(0.5, 0.6, 0.7, 1.0);" +
-"}" 
-      params = params || {}
-      for(var key in params) {
-        var matcher = new RegExp("{{"+key+"}}","g")
-        template = template.replace(matcher, params[key])
-      }
-      return template
-    };
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+module.exports = "void main() { \n" +" \n" +
+"  gl_FragColor = vec4(0.5, 0.6, 0.7, 1.0); \n" +" \n" +
+"} \n" ;
 
 },{}],2:[function(require,module,exports){
 
@@ -23,8 +15,15 @@ gl.clear(gl.COLOR_BUFFER_BIT);
 
 var prog = gl.createProgram();
 
-addShader(gl.createShader(gl.VERTEX_SHADER), vs());
-addShader(gl.createShader(gl.FRAGMENT_SHADER), fs());
+if (typeof vs === "function"){
+  vs = vs();
+}
+if (typeof fs === "function"){
+  fs = fs();
+}
+
+addShader(gl.createShader(gl.VERTEX_SHADER), vs);
+addShader(gl.createShader(gl.FRAGMENT_SHADER), fs);
 
 gl.linkProgram(prog);
 gl.useProgram(prog);
@@ -57,17 +56,9 @@ function addShader(shader, source) {
 
 
 },{"./fragment.c":1,"./vertex.c":3}],3:[function(require,module,exports){
-module.exports = function parse(params){
-      var template = "attribute vec3 pos;" +
-"void main() {" +
-"  gl_Position = vec4(pos, 1.0);" +
-"}" 
-      params = params || {}
-      for(var key in params) {
-        var matcher = new RegExp("{{"+key+"}}","g")
-        template = template.replace(matcher, params[key])
-      }
-      return template
-    };
+module.exports = "attribute vec3 pos; \n" +" \n" +
+"void main() { \n" +" \n" +
+"  gl_Position = vec4(pos, 1.0); \n" +" \n" +
+"} \n" ;
 
-},{}]},{},[2])
+},{}]},{},[2]);

--- a/example/index.js
+++ b/example/index.js
@@ -9,8 +9,15 @@ gl.clear(gl.COLOR_BUFFER_BIT);
 
 var prog = gl.createProgram();
 
-addShader(gl.createShader(gl.VERTEX_SHADER), vs());
-addShader(gl.createShader(gl.FRAGMENT_SHADER), fs());
+if (typeof vs === "function"){
+  vs = vs();
+}
+if (typeof fs === "function"){
+  fs = fs();
+}
+
+addShader(gl.createShader(gl.VERTEX_SHADER), vs);
+addShader(gl.createShader(gl.FRAGMENT_SHADER), fs);
 
 gl.linkProgram(prog);
 gl.useProgram(prog);

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ middleware.extensions = [
 /**
  *  create middleware for handling shader files
  */
-function middleware(file) {
+function middleware(file, options) {
   var matcher = new RegExp("\\."+ middleware.extensions.join("|")+"$")
   if (!matcher.test(file)) return through();
 
@@ -32,7 +32,7 @@ function middleware(file) {
   }
 
   var end = function () {
-    this.queue(createModule(input));
+    this.queue(createModule(input, options));
     this.queue(null);
   }
 
@@ -40,12 +40,19 @@ function middleware(file) {
 
 }
   /**
-   *  create commonJS module for the loaded shader
+   *  create module for the loaded shader
    */
-  function createModule(body, file) {
-      var text = middleware.sanitize(body)
-      var wrap = middleware.parameterise(text)
-      var module = 'module.exports = ' + wrap + ';\n';
+  function createModule(body, options) {
+      body = middleware.sanitize(body)
+      if (String(options.parameterize) !== 'false') {
+          body = middleware.parameterise(body)
+      }
+      if (options.module === "es6" || options.module === "es2015") {
+          var module = 'export default const shader = ' + body + ';\n';
+      }
+      else {
+          var module = 'module.exports = ' + body + ';\n';
+      }
       return module
     };
   

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function middleware(file, options) {
           body = middleware.parameterise(body)
       }
       if (options.module === "es6" || options.module === "es2015") {
-          var module = 'export default const shader = ' + body + ';\n';
+          var module = 'export default ' + body + ';\n';
       }
       else {
           var module = 'module.exports = ' + body + ';\n';


### PR DESCRIPTION
parameterize can be disabled with `{parameterize: false}` and es6
modules can be used instead of commonjs with `{module: 'es6'}`

defaults are same as before